### PR TITLE
Add support for per-method lifecycle in `SessionFactoryScopeExtension`

### DIFF
--- a/src/test/java/org/hibernate/sebersole/pg/junit5/functional/TheMethodBasedTests.java
+++ b/src/test/java/org/hibernate/sebersole/pg/junit5/functional/TheMethodBasedTests.java
@@ -1,0 +1,106 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.sebersole.pg.junit5.functional;
+
+import org.hibernate.sebersole.pg.junit5.stubs.H2Dialect;
+import org.hibernate.sebersole.pg.junit5.stubs.OracleDialect;
+import org.hibernate.sebersole.pg.junit5.stubs.SessionFactory;
+import org.hibernate.sebersole.pg.junit5.stubs.SessionFactoryStub;
+import org.hibernate.sebersole.pg.junit5.testing.FunctionalSessionFactoryTesting;
+import org.hibernate.sebersole.pg.junit5.testing.PerMethodFunctionalSessionFactoryTesting;
+import org.hibernate.sebersole.pg.junit5.testing.RequiresDialect;
+import org.hibernate.sebersole.pg.junit5.testing.SessionFactoryProducer;
+import org.hibernate.sebersole.pg.junit5.testing.SessionFactoryScope;
+import org.hibernate.sebersole.pg.junit5.testing.SessionFactoryScopeContainer;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Steve Ebersole
+ */
+@SuppressWarnings("WeakerAccess")
+@PerMethodFunctionalSessionFactoryTesting
+public class TheMethodBasedTests
+		implements SessionFactoryProducer, SessionFactoryScopeContainer {
+
+	private SessionFactoryScope sessionFactoryScope;
+
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// SessionFactoryProducer
+
+	@Override
+	public SessionFactory produceSessionFactory() {
+		System.out.println( "TheMethodBasedTests#produceSessionFactory");
+		return new SessionFactoryStub( new H2Dialect() );
+	}
+
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// SessionFactoryScopeContainer
+
+	@Override
+	public void injectSessionFactoryScope(SessionFactoryScope scope) {
+		System.out.println( "TheMethodBasedTests#injectSessionFactoryScope");
+		this.sessionFactoryScope = scope;
+	}
+
+	@Override
+	public SessionFactoryProducer getSessionFactoryProducer() {
+		return this;
+	}
+
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// tests
+
+	public TheMethodBasedTests() {
+		System.out.println( "TheMethodBasedTests#<init>");
+	}
+
+	@BeforeAll
+	public static void beforeAll() {
+		System.out.println();
+		System.out.println( "TheMethodBasedTests#@BeforeAll");
+	}
+
+	@BeforeEach
+	public void beforeEach() {
+		System.out.println( "TheMethodBasedTests#@BeforeEach");
+	}
+
+	@AfterEach
+	public void afterEach() {
+		System.out.println( "TheMethodBasedTests#@AfterEach");
+	}
+
+	@AfterAll
+	public static void afterAll() {
+		System.out.println( "TheMethodBasedTests#@AfterAll");
+	}
+
+	@Test
+	public void test1() {
+		sessionFactoryScope.withSession(
+				session -> System.out.println( "TheMethodBasedTests#test1 - withSession( " + session + ")" )
+		);
+	}
+
+	@Test
+	public void test2() {
+		sessionFactoryScope.withSession(
+				session -> System.out.println( "TheMethodBasedTests#test2 - withSession( " + session + ")" )
+		);
+	}
+
+	@Test
+	@RequiresDialect( dialectClass = OracleDialect.class )
+	public void filtered() {
+		System.out.println( "TheMethodBasedTests#filtered" );
+	}
+}

--- a/src/test/java/org/hibernate/sebersole/pg/junit5/testing/DialectFilterExtension.java
+++ b/src/test/java/org/hibernate/sebersole/pg/junit5/testing/DialectFilterExtension.java
@@ -31,8 +31,8 @@ public class DialectFilterExtension implements ExecutionCondition {
 		}
 
 		final Object testInstance = context.getRequiredTestInstance();
-		final ExtensionContext.Store store = context.getStore( SessionFactoryScopeExtension.NAMESPACE );
-		final SessionFactoryScope sfScope = (SessionFactoryScope) store.get( testInstance );
+		final ExtensionContext.Store store = context.getStore( SessionFactoryScopeExtension.namespace( testInstance ) );
+		final SessionFactoryScope sfScope = (SessionFactoryScope) store.get( SessionFactoryScopeExtension.SESSION_FACTORY_KEY );
 		if ( sfScope == null ) {
 			throw new RuntimeException( "Could not locate SessionFactoryScope in JUnit ExtensionContext" );
 		}

--- a/src/test/java/org/hibernate/sebersole/pg/junit5/testing/PerMethodFunctionalSessionFactoryTesting.java
+++ b/src/test/java/org/hibernate/sebersole/pg/junit5/testing/PerMethodFunctionalSessionFactoryTesting.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.sebersole.pg.junit5.testing;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Composite annotation for functional tests that
+ * require a functioning SessionFactory.
+ *
+ * @see SessionFactoryScopeExtension
+ * @see DialectFilterExtension
+ * @see FailureExpectedExtension
+ *
+ * @author Steve Ebersole
+ */
+@Retention( RetentionPolicy.RUNTIME )
+@Target(ElementType.TYPE)
+@TestInstance( TestInstance.Lifecycle.PER_METHOD )
+@ExtendWith( SessionFactoryScopeExtension.class )
+@ExtendWith( DialectFilterExtension.class )
+@ExtendWith( FailureExpectedExtension.class )
+public @interface PerMethodFunctionalSessionFactoryTesting {
+}

--- a/src/test/java/org/hibernate/sebersole/pg/junit5/testing/SessionFactoryScopeExtension.java
+++ b/src/test/java/org/hibernate/sebersole/pg/junit5/testing/SessionFactoryScopeExtension.java
@@ -6,9 +6,13 @@
  */
 package org.hibernate.sebersole.pg.junit5.testing;
 
+import java.util.Optional;
+
 import org.hibernate.sebersole.pg.junit5.stubs.SessionFactory;
 
 import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 
@@ -25,29 +29,75 @@ import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.create;
  * @author Steve Ebersole
  */
 public class SessionFactoryScopeExtension
-		implements TestInstancePostProcessor, AfterAllCallback {
+		implements TestInstancePostProcessor, BeforeAllCallback, AfterEachCallback, AfterAllCallback {
 
-	public static final ExtensionContext.Namespace NAMESPACE = create( SessionFactoryScopeExtension.class.getName() );
+	public static ExtensionContext.Namespace namespace(Object testInstance) {
+		return create( SessionFactoryScopeExtension.class.getName(), testInstance );
+	}
+
+	public static final Object SESSION_FACTORY_KEY = "SESSION_FACTORY";
+
+	private static final Object IS_LIFECYCLE_PER_CLASS_KEY = "IS_LIFECYCLE_PER_CLASS";
 
 	public SessionFactoryScopeExtension() {
 		System.out.println( "SessionFactoryScopeExtension#<init>" );
 	}
 
+	private void releaseSessionFactoryIfPresent(Object testInstance, ExtensionContext context) {
+		// We need the exact same context the session factory was defined on, i.e. the class context
+		// Otherwise the remove() operation on the store would not work
+		if ( context.getTestMethod().isPresent() ) {
+			context = context.getParent().get();
+		}
+		ExtensionContext.Store store = context.getStore( namespace( testInstance ) );
+		final SessionFactoryScope scope = (SessionFactoryScope) store.remove( SESSION_FACTORY_KEY );
+		if ( scope != null ) {
+			scope.releaseSessionFactory();
+		}
+	}
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// TestInstancePostProcessor
 
 	@Override
-	public void postProcessTestInstance(Object testInstance, ExtensionContext context) {
+	public void postProcessTestInstance(Object testInstance, ExtensionContext context) throws Exception {
 		System.out.println( "SessionFactoryScopeExtension#postProcessTestInstance" );
-
 		if ( SessionFactoryScopeContainer.class.isInstance( testInstance ) ) {
 			final SessionFactoryScopeContainer scopeContainer = SessionFactoryScopeContainer.class.cast(
 					testInstance );
 			final SessionFactoryScope scope = new SessionFactoryScope( scopeContainer.getSessionFactoryProducer() );
-			context.getStore( NAMESPACE ).put( testInstance, scope );
+			ExtensionContext.Store store = context.getStore( namespace( testInstance ) );
+			store.put( SESSION_FACTORY_KEY, scope );
 
 			scopeContainer.injectSessionFactoryScope( scope );
+		}
+	}
+
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// BeforeAllCallback
+
+	@Override
+	public void beforeAll(ExtensionContext context) throws Exception {
+		System.out.println( "SessionFactoryScopeExtension#beforeAll" );
+		Optional<Object> testInstanceOptional = context.getTestInstance();
+		if ( testInstanceOptional.isPresent() ) {
+			Object testInstance = testInstanceOptional.get();
+			ExtensionContext.Store store = context.getStore( namespace( testInstance ) );
+			store.put( IS_LIFECYCLE_PER_CLASS_KEY, IS_LIFECYCLE_PER_CLASS_KEY );
+		}
+	}
+
+
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	// AfterEachCallback
+
+	@Override
+	public void afterEach(ExtensionContext context) throws Exception {
+		System.out.println( "SessionFactoryScopeExtension#afterEach" );
+		Object testInstance = context.getRequiredTestInstance();
+		ExtensionContext.Store store = context.getStore( namespace( testInstance ) );
+		if ( store.get( IS_LIFECYCLE_PER_CLASS_KEY ) == null ) {
+			releaseSessionFactoryIfPresent( testInstance, context );
 		}
 	}
 
@@ -57,10 +107,13 @@ public class SessionFactoryScopeExtension
 
 	@Override
 	public void afterAll(ExtensionContext context) {
-		final SessionFactoryScope scope = (SessionFactoryScope) context.getStore( NAMESPACE )
-				.remove( context.getRequiredTestInstance() );
-		if ( scope != null ) {
-			scope.releaseSessionFactory();
+		System.out.println( "SessionFactoryScopeExtension#afterAll" );
+		Optional<Object> testInstanceOptional = context.getTestInstance();
+		if ( testInstanceOptional.isPresent() ) {
+			Object testInstance = testInstanceOptional.get();
+			ExtensionContext.Store store = context.getStore( namespace( testInstance ) );
+			store.remove( IS_LIFECYCLE_PER_CLASS_KEY );
+			releaseSessionFactoryIfPresent( testInstance, context );
 		}
 	}
 }


### PR DESCRIPTION
This makes the `SessionFactoryScopeExtension` compatible with a per-method lifecycle, while still retaining compatibility with the per-class lifecycle.

The per-method lifecycle is sometimes more practical, in particular with tests or extensions that could potentially mess with the internal state of the `SessionFactory` (or of the Hibernate Search `SearchIntegrator`).

Also, we could imagine (ultimately) to allow the test methods to provide additional parameters when building the session factory, for instance by calling mutators on the `SessionFactoryProducer` before the `SessionFactory` is requested. In that case, the per-method lifecycle would obviously be mandatory, and we probably couldn't use `@RequiresDialect` and co., but we would be able to test multiple bootstraps in a single test class: useful to test for bootstrap failures in particular.